### PR TITLE
Fix addRawArguments example

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Conditionally, depending on the result of an expression:
 
 ```php
     $builder
-        ->addArguments([
+        ->addRawArguments([
             '--foo=bar',
             '-xzcf',
             'if=/dev/sda of=/dev/sdb'


### PR DESCRIPTION
The last example for adding multiple conditional raw arguments was
referencing the `addArguments()` method instead of the
`addrawArguments()` method.